### PR TITLE
feat(lsp): adding user configs for LSP servers

### DIFF
--- a/lua/lvim/lsp/config.lua
+++ b/lua/lvim/lsp/config.lua
@@ -62,5 +62,6 @@ return {
       "tailwindcss",
       "volar",
     },
+    manual_config = {},
   },
 }

--- a/lua/lvim/lsp/manager.lua
+++ b/lua/lvim/lsp/manager.lua
@@ -32,6 +32,10 @@ local function resolve_config(name, user_config)
     config = vim.tbl_deep_extend("force", config, custom_config)
   end
 
+  if lvim.lsp.servers.manual_config[name] then
+    config = vim.tbl_deep_extend("force", config, lvim.lsp.servers.manual_config[name])
+  end
+
   if user_config then
     config = vim.tbl_deep_extend("force", config, user_config)
   end


### PR DESCRIPTION
Hi @kylo252,
Here is my [suggestion](https://github.com/LunarVim/LunarVim/pull/1762#issuecomment-942636785) for LunarVim#1762. I have rebased my suggested changes onto the branch from that PR.

I think after this the `lvim.lsp.servers.manual_setup_list` is not required. Any server that is not overridden (on the manual install list) can be modified using `lvim.lsp.servers.manual_config` like so:
```lua
lvim.lsp.servers.manual_config = {
  -- Sumneko_Lua {{{
  sumneko_lua = {
    settings = {
      Lua = {
        diagnostics = {
          globals = { "vim", "lvim", "hs" },
        },
        workspace = {
          library = {
            [require("lvim.utils").join_paths(get_runtime_dir(), "lvim", "lua")] = true,
            [vim.fn.expand("$VIMRUNTIME/lua")] = true,
            [vim.fn.expand("$VIMRUNTIME/lua/vim/lsp")] = true,
            ["/Applications/Hammerspoon.app/Contents/Resources/extensions/hs"] = (vim.fn.has("macunix") == 1),
          },
          maxPreload = 100000,
          preloadFileSize = 10000,
        },
        telemetry = { enable = false },
      },
    },
  },
  -- }}}
}
```

Also using this, all the "manual setup" servers can still reuse the auto-generated `ftplugin` files. Which I think is a nice feature to have.